### PR TITLE
Add optional alias to chatterbox_load_from_file

### DIFF
--- a/scripts/chatterbox_load_from_file/chatterbox_load_from_file.gml
+++ b/scripts/chatterbox_load_from_file/chatterbox_load_from_file.gml
@@ -3,9 +3,9 @@
 /// To find out more about Chatterbox's scripting language, "Yarn", please read the __chatterbox_syntax()
 ///
 /// @param filename  Name of the file to add
-/// @param [optional_alias] Alias for the filename
+/// @param [aliasName] Alias for the filename
 
-function chatterbox_load_from_file(_filename, _alias)
+function chatterbox_load_from_file(_filename, _aliasName)
 {
     if (!is_string(_filename))
     {
@@ -13,7 +13,7 @@ function chatterbox_load_from_file(_filename, _alias)
         return undefined;
     }
 	
-	if (_alias != undefined && !is_string(_alias))
+	if (_aliasName != undefined && !is_string(_aliasName))
 	{
 		__chatterbox_error("Aliases for filenames should be a string.\n(Input was an invalid datatype)");
 		return undefined;
@@ -32,9 +32,9 @@ function chatterbox_load_from_file(_filename, _alias)
     if (os_browser == browser_not_a_browser)
     {
         var _buffer = buffer_load(_font_directory + _filename);
-		if (_alias != undefined)
+		if (_aliasName != undefined)
 		{
-			return chatterbox_load_from_buffer(_alias, _buffer);
+			return chatterbox_load_from_buffer(_aliasName, _buffer);
 		}
 		else
 		{
@@ -50,9 +50,9 @@ function chatterbox_load_from_file(_filename, _alias)
         while(!file_text_eof(_file)) _string += file_text_readln(_file);
         file_text_close(_file);
         
-		if (_alias != undefined)
+		if (_aliasName != undefined)
 		{
-			return chatterbox_load_from_string(_alias, _string);
+			return chatterbox_load_from_string(_aliasName, _string);
 		}
 		else
 		{

--- a/scripts/chatterbox_load_from_file/chatterbox_load_from_file.gml
+++ b/scripts/chatterbox_load_from_file/chatterbox_load_from_file.gml
@@ -3,20 +3,26 @@
 /// To find out more about Chatterbox's scripting language, "Yarn", please read the __chatterbox_syntax()
 ///
 /// @param filename  Name of the file to add
+/// @param [optional_alias] Alias for the filename
 
-function chatterbox_load_from_file(_filename)
+function chatterbox_load_from_file(_filename, _alias)
 {
     if (!is_string(_filename))
     {
         __chatterbox_error("Files should be loaded using their filename as a string.\n(Input was an invalid datatype)");
         return undefined;
     }
+	
+	if (_alias != undefined && !is_string(_alias))
+	{
+		__chatterbox_error("Aliases for filenames should be a string.\n(Input was an invalid datatype)");
+		return undefined;
+	}
     
     //Fix the font directory name if it's weird
     var _font_directory = CHATTERBOX_SOURCE_DIRECTORY;
     var _char = string_char_at(_font_directory , string_length(_font_directory ));
     if (_char != "\\") && (_char != "/") _font_directory += "\\";
-    
     if (!file_exists(_font_directory + _filename))
     {
         __chatterbox_error("\"", _filename, "\" could not be found");
@@ -26,7 +32,14 @@ function chatterbox_load_from_file(_filename)
     if (os_browser == browser_not_a_browser)
     {
         var _buffer = buffer_load(_font_directory + _filename);
-        return chatterbox_load_from_buffer(_filename, _buffer);
+		if (_alias != undefined)
+		{
+			return chatterbox_load_from_buffer(_alias, _buffer);
+		}
+		else
+		{
+			return chatterbox_load_from_buffer(_filename, _buffer);
+		}
     }
     else
     {
@@ -37,6 +50,13 @@ function chatterbox_load_from_file(_filename)
         while(!file_text_eof(_file)) _string += file_text_readln(_file);
         file_text_close(_file);
         
-        return chatterbox_load_from_string(_filename, _string);
+		if (_alias != undefined)
+		{
+			return chatterbox_load_from_string(_alias, _string);
+		}
+		else
+		{
+			return chatterbox_load_from_string(_filename, _string);
+		}
     }
 }


### PR DESCRIPTION
The reason this is needed is because all the other `chatterbox_load_*` functions you could name the `filename` whatever you wanted because you were supplying your own data. With `chatterbox_load_from_file` you were forced to stick with the full name of the file, and this could contain unwanted directories/the full path name depending on how you're loading your files. This gives more control over how you want your chatterboxes to be created within your code.

Now you can do this:
```gml
chatterbox_load_from_file("Folder/Another_Folder/My_Yarn_File.yarn", "My_Alternative_Name");
chatter = chatterbox_create("My_Alternative_Name");
```
Instead of
```gml
chatterbox_load_from_file("Folder/Another_Folder/My_Yarn_File.yarn");
chatter = chatterbox_create("Folder/Another_Folder/My_Yarn_File.yarn");
```