### PR TITLE
Incredible comma fix

### DIFF
--- a/scripts/ChatterboxAddFunction/ChatterboxAddFunction.gml
+++ b/scripts/ChatterboxAddFunction/ChatterboxAddFunction.gml
@@ -20,7 +20,7 @@
 /// 
 /// Custom functions can be added at any point but should be added before loading in any source files.
 /// 
-/// @param name      Script name, as a string
+/// @param name      Script name; as a string
 /// @param function  Function to call
 
 function ChatterboxAddFunction(_name, _in_function)

--- a/scripts/ChatterboxLoadFromFile/ChatterboxLoadFromFile.gml
+++ b/scripts/ChatterboxLoadFromFile/ChatterboxLoadFromFile.gml
@@ -2,7 +2,7 @@
 ///
 /// To find out more about Chatterbox's scripting language, "Yarn", please read the __chatterbox_syntax()
 ///
-/// @param path         Path to the file to add, relative to CHATTERBOX_INCLUDED_FILES_SUBDIRECTORY
+/// @param path         Path to the file to add; relative to CHATTERBOX_INCLUDED_FILES_SUBDIRECTORY
 /// @param [aliasName]  Alias for this file
 
 function ChatterboxLoadFromFile()


### PR DESCRIPTION
GMS's implementation of JSdoc has a quirk where within peram descriptions, if there's a comma, it treats it as a separator for a new argument.

For two different functions, this made it look as though they had 3 arguments rather than 2.

Changing it to another character (I chose semi-colons) fixes the issue.