### PR TITLE
Documentation renaming 

### DIFF
--- a/docs/1.1.3/_sidebar.md
+++ b/docs/1.1.3/_sidebar.md
@@ -6,7 +6,7 @@
 
 -   [Yarn Script](concept-yarn-script)
 -   [Source Files](concept-source-files)
--   [Chatterboxes](concept-chatterboxes)
+-   [How to use](concept-chatterboxes)
 
 ---
 

--- a/docs/1.1.3/concept-chatterboxes.md
+++ b/docs/1.1.3/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.1/concept-chatterboxes.md
+++ b/docs/2.1/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.2/concept-chatterboxes.md
+++ b/docs/2.2/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.3/concept-chatterboxes.md
+++ b/docs/2.3/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.4/concept-chatterboxes.md
+++ b/docs/2.4/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.5/concept-chatterboxes.md
+++ b/docs/2.5/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/2.6/concept-chatterboxes.md
+++ b/docs/2.6/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,7 +6,7 @@
 
 -   [Yarn Script](concept-yarn-script)
 -   [Source Files](concept-source-files)
--   [Chatterboxes](concept-chatterboxes)
+-   [How to use](concept-chatterboxes)
 
 ---
 

--- a/docs/latest/concept-chatterboxes.md
+++ b/docs/latest/concept-chatterboxes.md
@@ -1,4 +1,4 @@
-# Chatterboxes
+# How to Use Chatterboxes
 
 ---
 


### PR DESCRIPTION
Sidebar text "chatterboxes" -> "How to use", for more clarity.