### PR TITLE
Fixed Typo in Splitbody function

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Juju Adams
+Copyright (c) 2023 Julian Adams
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/datafiles/chatterbox_license.txt
+++ b/datafiles/chatterbox_license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Julian Adams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/__ChatterboxSplitBody/__ChatterboxSplitBody.gml
+++ b/scripts/__ChatterboxSplitBody/__ChatterboxSplitBody.gml
@@ -229,7 +229,6 @@ function __ChatterboxSplitBody(_source_buffer, _source_buffer_start, _source_buf
                 _func_read_string(_substring_array,
                                   _buffer, _string_start, _string_end,
                                   _type, _line, _indent,
-                                  _line, _indent,
                                   _buffer_offset);
                 
                 _type = _line_is_option? "option" : "text";


### PR DESCRIPTION

Only lines with text and an action had their line numbers missplaced, which made the yarn file unusable after LocalizationBuild.

**Yarn file example:**

```
    -> SO YOU ARE LOKI? <<if !visited("SOYOUARELOKI")>>
        <<hop SOYOUARELOKI>>
    -> WHO AM I? <<if !visited("WHOAMI")>>
        <<hop WHOAMI>>
    -> ARE WE TRAPPED HERE? <<if !visited("AREWETRAPPED")>>
        <<hop AREWETRAPPED>>
```
```
    -> SO YOU ARE LOKI? <<if !visited("SOYOUARELOKI")>>
     #line:2ebadd    <<hop SOYOUARELOKI>>
    -> WHO AM I? <<if !visited("WHOAMI")>>
       #line:1d79ad  <<hop WHOAMI>>
    -> ARE WE TRAPPED HERE? <<if !visited("AREWETRAPPED")>>
         #line:ffb29b<<hop AREWETRAPPED>>

```
