### PR TITLE
Fixed typo & fixed buffer_end on commands

### DIFF
--- a/scripts/__ChatterboxBufferBatch/__ChatterboxBufferBatch.gml
+++ b/scripts/__ChatterboxBufferBatch/__ChatterboxBufferBatch.gml
@@ -65,7 +65,7 @@ function __ChatterboxBufferBatch() constructor
     {
         if (__destroyed) __Error("Worker has been destroyed");
         
-        GetBuffer();
+        __GetBuffer();
         
         buffer_seek(__outBuffer, buffer_seek_start, 0);
         return buffer_read(__outBuffer, buffer_text);

--- a/scripts/__ChatterboxClassLine/__ChatterboxClassLine.gml
+++ b/scripts/__ChatterboxClassLine/__ChatterboxClassLine.gml
@@ -24,6 +24,10 @@ function __ChatterboxClassLine() constructor
                     array_push(__hash_array, string_delete(_text, 1, __CHATTERBOX_LINE_HASH_PREFIX_LENGTH));
                 }
             break;
+            case "command":
+                // Removes the ">>" correctly on commands
+                _substring.buffer_end = _substring.buffer_end + 2
+            break;
         }
         
         array_push(__substring_array, _substring);


### PR DESCRIPTION
Some small fixes I have found when working on localizing the yarn file.


Before, the buffer_end would be incorrect due to not adding the last two arrows on commands. 
So build localisation would do this.
```
  -> DID ALL OF THAT REALLY HAPPEN? <<if !visited("DIDTHATREALLYHAPPEN")>#line:3808d4>
      <<hop DIDTHATREALLYHAPPEN>>
  -> SO YOU ARE LOKI? <<if !visited("SOYOUARELOKI")>#line:95ddba>
```
After 
```
  -> DID ALL OF THAT REALLY HAPPEN? <<if !visited("DIDTHATREALLYHAPPEN")>> #line:3808d4
      <<hop DIDTHATREALLYHAPPEN>>
  -> SO YOU ARE LOKI? <<if !visited("SOYOUARELOKI")>> #line:95ddba
```