### PR TITLE
Corrected variable names in getting started guide

### DIFF
--- a/docs/2.10/getting-started.md
+++ b/docs/2.10/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.11/getting-started.md
+++ b/docs/2.11/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.12/getting-started.md
+++ b/docs/2.12/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.13/getting-started.md
+++ b/docs/2.13/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.14/getting-started.md
+++ b/docs/2.14/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.16/getting-started.md
+++ b/docs/2.16/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.17/getting-started.md
+++ b/docs/2.17/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.18/getting-started.md
+++ b/docs/2.18/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.8/getting-started.md
+++ b/docs/2.8/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 

--- a/docs/2.9/getting-started.md
+++ b/docs/2.9/getting-started.md
@@ -141,16 +141,16 @@ Finally, you can completely stop processing in a chatterbox using `ChatterboxSto
 Here's an example of how to set up very simple user input, taken from the basic example in the GitHub repo.
 
 ```gml
-if (ChatterboxIsStopped(box))
+if (ChatterboxIsStopped(chatterbox))
 {
     //If we're stopped then don't respond to user input
 }
-else if (ChatterboxIsWaiting(box))
+else if (ChatterboxIsWaiting(chatterbox))
 {
     //If we're in a "waiting" state then let the user press <space> to advance dialogue
     if (keyboard_check_released(vk_space))
     {
-        ChatterboxContinue(box);
+        ChatterboxContinue(chatterbox);
     }
 }
 else
@@ -164,7 +164,7 @@ else
     if (keyboard_check_released(ord("4"))) _index = 3;
     
     //If we've pressed a button, select that option
-    if (_index != undefined) ChatterboxSelect(box, _index);
+    if (_index != undefined) ChatterboxSelect(chatterbox, _index);
 }
 ```
 


### PR DESCRIPTION
I was originally just going to do v2.18. Then I realized that every single version from v2.8 had the exact same issue.
SO, rather than just changing one and leaving the rest, I changed each and every single version for consistency sake.

The issue at hand was that in the step event of the getting started guide, `box` was used in place of `chatterbox`. So I've changed it back to `chatterbox`. 

I ran into this issue while I was actually making a very quick example about having multiple characters drawn at once