### PR TITLE
Docs: Updated all Discord invite links to point to the new one

### DIFF
--- a/docs/1.1/README.md
+++ b/docs/1.1/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.1 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/YarnSpinnerTool/YarnEditor/releases/" target="_blank">visual editor</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://yarnspinnertool.github.io/YarnEditor/) as well as [Windows, MacOS, & Ubuntu](https://github.com/YarnSpinnerTool/YarnEditor/releases/) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-setup#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [YarnEditor](https://github.com/YarnSpinnerTool/YarnEditor/) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [YarnEditor](https://github.com/YarnSpinnerTool/YarnEditor/) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.1/README.md
+++ b/docs/2.1/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.10/README.md
+++ b/docs/2.10/README.md
@@ -3,7 +3,7 @@
 <p align="center">Narrative engine for GameMaker 2022 LTS by <a href="https://www.jujuadams.com/" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -28,7 +28,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [YarnScript](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [YarnScript](concept-yarn-script) page.
 

--- a/docs/2.10/getting-started.md
+++ b/docs/2.10/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.11/README.md
+++ b/docs/2.11/README.md
@@ -28,7 +28,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [YarnScript](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [YarnScript](concept-yarn-script) page.
 

--- a/docs/2.11/getting-started.md
+++ b/docs/2.11/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.12/getting-started.md
+++ b/docs/2.12/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.13/getting-started.md
+++ b/docs/2.13/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.14/getting-started.md
+++ b/docs/2.14/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.15/getting-started.md
+++ b/docs/2.15/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.16/getting-started.md
+++ b/docs/2.16/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.17/getting-started.md
+++ b/docs/2.17/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.18/getting-started.md
+++ b/docs/2.18/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.2/README.md
+++ b/docs/2.2/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.3/README.md
+++ b/docs/2.3/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.4/README.md
+++ b/docs/2.4/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.5/README.md
+++ b/docs/2.5/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.6/README.md
+++ b/docs/2.6/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.7/README.md
+++ b/docs/2.7/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker Studio 2.3.2 by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [Yarn script](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [Yarn Script](concept-yarn-script) page.
 

--- a/docs/2.8/README.md
+++ b/docs/2.8/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker 2022 LTS by <a href="https://twitter.com/jujuadams" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---
@@ -32,7 +32,7 @@ Yarn files can be written by hand, but the best way to start with Yarn is to use
     Chatterbox is designed to be easy to implement and easy to make games with. [YarnScript](concept-yarn-script) can be written by hand or, more commonly, an editor is used to write your stories. There's a [web editor](https://faultyfunctions.github.io/Crochet/) as well as [Windows, MacOS, & Ubuntu](https://github.com/FaultyFunctions/Crochet/releases) binaries. Chatterbox loads in Yarn files straight from your [Included Files](https://manual.yoyogames.com/Settings/Included_Files.htm) with a [single command](reference-configuration#chatterboxloadfromfilefilename-aliasname) without any other setup.
 
 -   **Community**<br>
-    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/8krYCqr).
+    Yarn has a thriving community of narrative designers. The maintainers of Yarn run a [Slack group](http://lab.to/narrativegamedev) & [Discord server](https://discord.gg/yarnspinner), and [YarnSpinner](https://github.com/YarnSpinnerTool/) and [Crochet](https://faultyfunctions.github.io/Crochet/) (community maintained editor for Yarn v2) are constantly being updated. Chatterbox has a lively community too, based around our [Discord server](https://discord.gg/hwgWpnsNw2).
 
 ?> For a full explanation of Yarn's features and syntax, please read the [YarnScript](concept-yarn-script) page.
 

--- a/docs/2.8/getting-started.md
+++ b/docs/2.8/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).

--- a/docs/2.9/README.md
+++ b/docs/2.9/README.md
@@ -7,7 +7,7 @@
 <p align="center">Narrative engine for GameMaker 2022 LTS by <a href="https://www.jujuadams.com/" target="_blank">Juju Adams</a></p>
 
 <p align="center"><a href="https://github.com/JujuAdams/chatterbox/releases/" target="_blank">Download the .yymps</a></p>
-<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/8krYCqr" target="_blank">Discord server</a></p>
+<p align="center">Talk about Chatterbox on the <a href="https://discord.gg/hwgWpnsNw2" target="_blank">Discord server</a></p>
 <p align="center">Download the <a href="https://github.com/FaultyFunctions/YarnEditor/" target="_blank">visual editor</a> by <a href="https://twitter.com/FaultyFunctions" target="_blank">Faulty</a></p>
 
 ---

--- a/docs/3.0/getting-started.md
+++ b/docs/3.0/getting-started.md
@@ -276,4 +276,4 @@ Variables allow you to branch dialogue in response to a value that you're tracki
 
 ## Closing thoughts
 
-Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/8krYCqr).
+Chatterbox is a powerful tool and we've only scratched the surface. Please take the time to poke around the rest of the documentation and, if you have any questions, please swing by the [Discord server](https://discord.gg/hwgWpnsNw2).


### PR DESCRIPTION
People have been joining GameMaker Kitchen for Chatterbox support, despite being the wrong place for support.
This PR addresses this by replacing it with the Jujuverse Chatterbox Discord invite.